### PR TITLE
Fix cross-browser triple bond rendering issues

### DIFF
--- a/chemistry.css
+++ b/chemistry.css
@@ -54,126 +54,37 @@ hr{
 
 
 hr[triplebond]{
-    border-top: 2px black solid;
-    border-bottom: 2px black solid;
+    border: none;
     padding-bottom:0px !important;
     padding-top:3px !important;
     line-height: 0px;
     height:2px !important;
-
+    position: relative;
+    background: black;
+    box-shadow: 0 -4px 0 0 black, 0 4px 0 0 black;
 }
 
 
-div + hr[triplebond]::before{
-    content: '_________';
-    border-bottom: 2px !important;
-    position:absolute;
-    font-weight:900;
-    font-size:22px;
-    margin-left:-3px;
-    top:-14.5px;
-    bottom:20px;
-    width:100%;
 
-}
 
-div + hr + hr[triplebond]::before{
-    content: '______';
-    border-bottom: 2px !important;
-    position:absolute;
-    font-weight:900;
-    font-size:23.5px;
-    margin-left:-3px;
-    top:-14.5px;
-    bottom:20px;
-    width:100%;
 
-}
-
-div + hr + hr + hr[triplebond]::before{
-    content: '_________';
-    border-bottom: 2px !important;
-    position:absolute;
-    font-weight:900;
-    font-size:22px;
-    margin-left:-3px;
-    top:-14.5px;
-    bottom:20px;
-    width:100%;
-}
-
-div + hr + hr + hr + hr[triplebond]::before{
-    content: '_____';
-    border-bottom: 2px !important;
-    position:absolute;
-    font-weight:900;
-    font-size:21px;
-    margin-left:-3px;
-    top:-14.5px;
-    bottom:20px;
-    width:100%;
-}
 
 hr[partialtriplebond]{
-    border-top: 2px black solid;
-    border-bottom: 2px black dotted;
+    border: none;
     padding-bottom:0px !important;
     padding-top:3px !important;
     line-height: 0px;
     height:2px !important;
-
+    position: relative;
+    background: black;
+    box-shadow: 0 -4px 0 0 black;
+    border-bottom: 2px dotted black;
 }
 
 
-div + hr[partialtriplebond]::before{
-    content: '_________';
-    border-bottom: 2px !important;
-    position:absolute;
-    font-weight:900;
-    font-size:22px;
-    margin-left:-3px;
-    top:-14.5px;
-    bottom:20px;
-    width:100%;
 
-}
 
-div + hr + hr[partialtriplebond]::before{
-    content: '______';
-    border-bottom: 2px !important;
-    position:absolute;
-    font-weight:900;
-    font-size:23.5px;
-    margin-left:-3px;
-    top:-14.5px;
-    bottom:20px;
-    width:100%;
 
-}
-
-div + hr + hr + hr[partialtriplebond]::before{
-    content: '_________';
-    border-bottom: 2px !important;
-    position:absolute;
-    font-weight:900;
-    font-size:22px;
-    margin-left:-3px;
-    top:-14.5px;
-    bottom:20px;
-    width:100%;
-}
-
-div + hr + hr + hr + hr[partialtriplebond]::before{
-    content: '_____';
-    border-bottom: 2px !important;
-    position:absolute;
-    font-weight:900;
-    font-size:21px;
-    margin-left:-3px;
-    top:-14.5px;
-    bottom:20px;
-    width:100%;
-}
 
 
 


### PR DESCRIPTION
Replace underscore-based pseudo-elements with box-shadow approach for consistent triple bond display across Chrome, Safari, Firefox. Safari was not rendering ::before pseudo-elements on hr elements, causing triple bonds to appear as double bonds.

🤖 Co-Authored-By: Claude <noreply@anthropic.com>

Before
<img width="429" height="287" alt="before" src="https://github.com/user-attachments/assets/738ee9ab-887b-498e-9010-79d706cd4e52" />
After
<img width="521" height="307" alt="after" src="https://github.com/user-attachments/assets/3c0a3a0c-a22a-4ca0-b912-c1ea1d95a5e3" />

Before
<img width="755" height="338" alt="Cyanide-before" src="https://github.com/user-attachments/assets/ea273119-8198-41a3-9875-68c43170aef6" />

After
<img width="735" height="316" alt="Cyanide-after" src="https://github.com/user-attachments/assets/4fe00852-2d3e-4157-aa90-1454f65e0703" />
